### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: docs
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 .wrangler
 /.svelte-kit
 /build
+docs
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## Deployment
+
+This project uses [`@sveltejs/adapter-static`](https://github.com/sveltejs/kit/tree/master/packages/adapter-static) and a GitHub Actions workflow to deploy the built site to **GitHub Pages**. The adapter writes the build output to the `docs` directory so that GitHub Pages can serve it directly. Any changes pushed to the `main` branch automatically trigger a deployment to the `gh-pages` branch.
+
+The application is served from `/octo-presso`, so when developing locally the base path is `/` but in production it uses `/octo-presso`. The workflow uploads the `docs` directory as the artifact for GitHub Pages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 				"@fontsource/fira-mono": "^5.0.0",
 				"@neoconfetti/svelte": "^2.0.0",
 				"@sveltejs/adapter-auto": "^6.0.0",
+				"@sveltejs/adapter-static": "^3.0.8",
 				"@sveltejs/kit": "^2.16.0",
 				"@sveltejs/vite-plugin-svelte": "^5.0.0",
 				"svelte": "^5.25.0",
@@ -832,6 +833,16 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-6.0.1.tgz",
 			"integrity": "sha512-mcWud3pYGPWM2Pphdj8G9Qiq24nZ8L4LB7coCUckUEy5Y7wOWGJ/enaZ4AtJTcSm5dNK1rIkBRoqt+ae4zlxcQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@sveltejs/kit": "^2.0.0"
+			}
+		},
+		"node_modules/@sveltejs/adapter-static": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-3.0.8.tgz",
+			"integrity": "sha512-YaDrquRpZwfcXbnlDsSrBQNCChVOT9MGuSg+dMAyfsAa1SmiAhrA5jUYUiIMC59G92kIbY/AaQOWcBdq+lh+zg==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"@fontsource/fira-mono": "^5.0.0",
 		"@neoconfetti/svelte": "^2.0.0",
 		"@sveltejs/adapter-auto": "^6.0.0",
+		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.16.0",
 		"@sveltejs/vite-plugin-svelte": "^5.0.0",
 		"svelte": "^5.25.0",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,13 +1,18 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-static';
+
+const dev = process.env.NODE_ENV === 'development';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		// adapter-auto only supports some environments, see https://svelte.dev/docs/kit/adapter-auto for a list.
-		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
-		// See https://svelte.dev/docs/kit/adapters for more information about adapters.
-		adapter: adapter()
-	}
+      kit: {
+              adapter: adapter({
+                      pages: 'docs',
+                      assets: 'docs'
+              }),
+              paths: {
+                      base: dev ? '' : '/octo-presso'
+              }
+      }
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- add adapter-static and configure base path for GitHub pages
- document deployment setup in README
- add workflow to build and deploy to GitHub Pages
- build output set to `docs` so GitHub Pages can serve it

## Testing
- `npm install`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6841ec899b1c83258a0ef84313c353f5