### PR TITLE
Fix build path handling and enable static build

### DIFF
--- a/src/routes/Header.svelte
+++ b/src/routes/Header.svelte
@@ -1,7 +1,8 @@
 <script>
-	import { page } from '$app/state';
-	import logo from '$lib/images/svelte-logo.svg';
-	import github from '$lib/images/github.svg';
+       import { page } from '$app/state';
+       import { base } from '$app/paths';
+       import logo from '$lib/images/svelte-logo.svg';
+       import github from '$lib/images/github.svg';
 </script>
 
 <header>
@@ -16,15 +17,15 @@
 			<path d="M0,0 L1,2 C1.5,3 1.5,3 2,3 L2,0 Z" />
 		</svg>
 		<ul>
-			<li aria-current={page.url.pathname === '/' ? 'page' : undefined}>
-				<a href="/">Home</a>
-			</li>
-			<li aria-current={page.url.pathname === '/about' ? 'page' : undefined}>
-				<a href="/about">About</a>
-			</li>
-			<li aria-current={page.url.pathname.startsWith('/sverdle') ? 'page' : undefined}>
-				<a href="/sverdle">Sverdle</a>
-			</li>
+                       <li aria-current={page.url.pathname === base || page.url.pathname === base + '/' ? 'page' : undefined}>
+                               <a href={base || '/'}>Home</a>
+                       </li>
+                       <li aria-current={page.url.pathname.startsWith(`${base}/about`) ? 'page' : undefined}>
+                               <a href={`${base}/about`}>About</a>
+                       </li>
+                       <li aria-current={page.url.pathname.startsWith(`${base}/sverdle`) ? 'page' : undefined}>
+                               <a href={`${base}/sverdle`}>Sverdle</a>
+                       </li>
 		</ul>
 		<svg viewBox="0 0 2 3" aria-hidden="true">
 			<path d="M0,0 L0,3 C0.5,3 0.5,3 1,2 L2,0 Z" />

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,3 +1,7 @@
+<script>
+       import { base } from '$app/paths';
+</script>
+
 <svelte:head>
 	<title>About</title>
 	<meta name="description" content="About this app" />
@@ -20,7 +24,7 @@
 	</p>
 
 	<p>
-		The <a href="/sverdle">Sverdle</a> page illustrates SvelteKit's data loading and form handling. Try
+               The <a href={`${base}/sverdle`}>Sverdle</a> page illustrates SvelteKit's data loading and form handling. Try
 		using it with JavaScript disabled!
 	</p>
 </div>

--- a/src/routes/sverdle/+page.js
+++ b/src/routes/sverdle/+page.js
@@ -1,0 +1,1 @@
+export const prerender = false;

--- a/src/routes/sverdle/+page.server.js
+++ b/src/routes/sverdle/+page.server.js
@@ -1,6 +1,8 @@
 import { fail } from '@sveltejs/kit';
 import { Game } from './game';
 
+export const prerender = false;
+
 /** @satisfies {import('./$types').PageServerLoad} */
 export const load = ({ cookies }) => {
 	const game = new Game(cookies.get('sverdle'));

--- a/src/routes/sverdle/+page.svelte
+++ b/src/routes/sverdle/+page.svelte
@@ -1,8 +1,9 @@
 <script>
-	import { enhance } from '$app/forms';
-	import { confetti } from '@neoconfetti/svelte';
+       import { enhance } from '$app/forms';
+       import { confetti } from '@neoconfetti/svelte';
 
-	import { MediaQuery } from 'svelte/reactivity';
+       import { MediaQuery } from 'svelte/reactivity';
+       import { base } from '$app/paths';
 
 	/**
 	 * @typedef {Object} Props
@@ -111,7 +112,7 @@
 		};
 	}}
 >
-	<a class="how-to-play" href="/sverdle/how-to-play">How to play</a>
+       <a class="how-to-play" href={`${base}/sverdle/how-to-play`}>How to play</a>
 
 	<div class="grid" class:playing={!won} class:bad-guess={form?.badGuess}>
 		{#each Array.from(Array(6).keys()) as row (row)}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -5,7 +5,7 @@ const dev = process.env.NODE_ENV === 'development';
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
       kit: {
-              adapter: adapter(),
+              adapter: adapter({ strict: false }),
               paths: {
                       base: dev ? '' : '/octo-presso'
               }


### PR DESCRIPTION
## Summary
- respect `$app/paths.base` in nav links and routes
- allow `/sverdle` to remain dynamic
- disable adapter strict mode for static sites

## Testing
- `npm run build`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6841f00dbff08325b16e8f8e5f0efffd