### PR TITLE
Fix GitHub Pages artifact path

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,7 +26,7 @@ jobs:
       - run: npm run build
       - uses: actions/upload-pages-artifact@v1
         with:
-          path: build
+          path: docs
   deploy:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- update GitHub Pages workflow to upload the `docs` directory

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841f749b5288325a02f96c3b265badc