### PR TITLE
Fix dev base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,4 @@ You can preview the production build with `npm run preview`.
 This project uses [`@sveltejs/adapter-static`](https://github.com/sveltejs/kit/tree/master/packages/adapter-static) and a GitHub Actions workflow to deploy the built site to **GitHub Pages**. Any changes pushed to the `main` branch automatically trigger a deployment to the `gh-pages` branch.
 
 The application is served from `/octo-presso`, so when developing locally the base path is `/` but in production it uses `/octo-presso`.
+The `svelte.config.js` file now sets this automatically based on `NODE_ENV`, so no manual edits are necessary.

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,7 @@
 import adapter from '@sveltejs/adapter-static';
 
+const dev = process.env.NODE_ENV === 'development';
+
 export default {
   kit: {
     adapter: adapter({
@@ -8,7 +10,7 @@ export default {
       fallback: null
     }),
     paths: {
-      base: '/octo-presso',    // optional: for GitHub Pages or subdir deploys
+      base: dev ? '' : '/octo-presso',    // optional: for GitHub Pages or subdir deploys
     }
   }
 };


### PR DESCRIPTION
## Summary
- switch SvelteKit base path depending on NODE_ENV
- note auto base path selection in README

## Testing
- `npm run dev`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68420437ea8483259aa129d7587f6557