### PR TITLE
Add marketing page examples

### DIFF
--- a/src/lib/Features.svelte
+++ b/src/lib/Features.svelte
@@ -1,0 +1,19 @@
+<script>
+  export let features = [];
+</script>
+
+<section class="py-16 bg-gray-100">
+  <div class="max-w-6xl mx-auto px-6">
+    <div class="grid gap-10 md:grid-cols-3">
+      {#each features as feat}
+        <div class="text-center">
+          <div class="mx-auto mb-4 text-5xl" style="color: var(--color-theme-1)">
+            {@html feat.icon}
+          </div>
+          <h3 class="text-xl font-semibold mb-2">{feat.title}</h3>
+          <p class="text-gray-600">{feat.text}</p>
+        </div>
+      {/each}
+    </div>
+  </div>
+</section>

--- a/src/lib/Hero.svelte
+++ b/src/lib/Hero.svelte
@@ -1,0 +1,28 @@
+<script>
+  export let title;
+  export let subtitle = '';
+  export let image = '';
+  export let ctaText = '';
+  export let ctaLink = '#';
+</script>
+
+<section class="bg-gray-900 text-white">
+  <div class="max-w-6xl mx-auto px-6 py-24 flex flex-col md:flex-row items-center gap-8">
+    <div class="md:w-1/2 text-center md:text-left">
+      <h1 class="text-4xl md:text-5xl font-extrabold mb-6">{title}</h1>
+      {#if subtitle}
+        <p class="text-xl mb-8 opacity-80">{subtitle}</p>
+      {/if}
+      {#if ctaText}
+        <a href={ctaLink} class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">
+          {ctaText}
+        </a>
+      {/if}
+    </div>
+    {#if image}
+      <div class="md:w-1/2">
+        <img class="rounded-xl shadow-xl w-full" src={image} alt={title} />
+      </div>
+    {/if}
+  </div>
+</section>

--- a/src/routes/music/+page.svelte
+++ b/src/routes/music/+page.svelte
@@ -1,0 +1,37 @@
+<script>
+  import Hero from '$lib/Hero.svelte';
+  import Features from '$lib/Features.svelte';
+
+  const features = [
+    {
+      icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M9 18V5l12-2v13" /></svg>`,
+      title: 'Hi‑Fi Sound',
+      text: 'Crystal clear audio engineered for true music lovers.'
+    },
+    {
+      icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-2M9 12l10.5-2M9 15l7.125-1.357" /><path stroke-linecap="round" stroke-linejoin="round" d="M9 9v12.75a.75.75 0 01-1.06.697l-4.5-2.25A.75.75 0 013 19.75V7.913a.75.75 0 01.44-.685L8 5.158a.75.75 0 011 .685V9z" /></svg>`,
+      title: 'Offline Playback',
+      text: 'Download your favorites and listen anywhere.'
+    },
+    {
+      icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M9.75 15.75v2.25A2.25 2.25 0 0012 20.25h0a2.25 2.25 0 002.25-2.25v-2.25M12 13.5v6m0 0h3.164c.597 0 1.079-.463 1.079-1.033a10.5 10.5 0 00-8.486 0c0 .57.482 1.033 1.08 1.033H12z" /><circle cx="12" cy="7" r="4.5" /></svg>`,
+      title: 'Curated Playlists',
+      text: 'Fresh tracks handpicked every single day.'
+    }
+  ];
+</script>
+
+<Hero
+  title="Experience Music Like Never Before"
+  subtitle="Stream millions of songs ad‑free."
+  image="https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?auto=format&fit=crop&w=1200&q=80"
+  ctaText="Start Listening"
+  ctaLink="#"
+/>
+
+<Features {features} />
+
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Ready to tune in?</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Join Now</a>
+</section>

--- a/src/routes/performance/+page.svelte
+++ b/src/routes/performance/+page.svelte
@@ -1,0 +1,37 @@
+<script>
+  import Hero from '$lib/Hero.svelte';
+  import Features from '$lib/Features.svelte';
+
+  const features = [
+    {
+      icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3h18l-1.5 2.25L21 7.5H3L4.5 5.25 3 3z" /><path stroke-linecap="round" stroke-linejoin="round" d="M3 7.5h18v11.25A1.5 1.5 0 0119.5 20.25h-15A1.5 1.5 0 013 18.75V7.5z" /></svg>`,
+      title: 'Blazing Fast',
+      text: 'Optimized for speed from the ground up.'
+    },
+    {
+      icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3h18M6 5v14m12-14v14" /></svg>`,
+      title: 'Scalable',
+      text: 'Handles projects big and small with ease.'
+    },
+    {
+      icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><circle cx="12" cy="12" r="9" /><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l3 3" /></svg>`,
+      title: 'Real-time Updates',
+      text: 'Stay in sync with live data at all times.'
+    }
+  ];
+</script>
+
+<Hero
+  title="Performance That Delights"
+  subtitle="Speed and efficiency for your modern apps."
+  image="https://images.unsplash.com/photo-1523113555484-94d9e2786a6a?auto=format&fit=crop&w=1200&q=80"
+  ctaText="Learn More"
+  ctaLink="#"
+/>
+
+<Features {features} />
+
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Supercharge your workflow</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Try it free</a>
+</section>

--- a/src/routes/ui/+page.svelte
+++ b/src/routes/ui/+page.svelte
@@ -1,0 +1,37 @@
+<script>
+  import Hero from '$lib/Hero.svelte';
+  import Features from '$lib/Features.svelte';
+
+  const features = [
+    {
+      icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3h18M9 3v18m6-18v18M3 21h18" /></svg>`,
+      title: 'Responsive Layouts',
+      text: 'Looks stunning on phones, tablets and desktops.'
+    },
+    {
+      icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12l-7.5 7.5M10.5 19.5L3 12l7.5-7.5" /></svg>`,
+      title: 'Intuitive Controls',
+      text: 'Simple, familiar interface designed for productivity.'
+    },
+    {
+      icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6h15m-15 6h15m-15 6h15" /></svg>`,
+      title: 'Accessible',
+      text: 'Built with best practices for every user in mind.'
+    }
+  ];
+</script>
+
+<Hero
+  title="Crafted User Interfaces"
+  subtitle="Beautiful components that simply work."
+  image="https://images.unsplash.com/photo-1503264116251-35a269479413?auto=format&fit=crop&w=1200&q=80"
+  ctaText="See Components"
+  ctaLink="#"
+/>
+
+<Features {features} />
+
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Build amazing apps today</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Get Started</a>
+</section>


### PR DESCRIPTION
## Summary
- add reusable `Hero` and `Features` components
- create example pages `/music`, `/ui` and `/performance`

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423bbb7100832596eeb6b74a514995