### PR TITLE
Refine example pages with custom layouts

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,23 +1,27 @@
 <script>
-	import Header from './Header.svelte';
-	import '../app.css';
+       import Header from './Header.svelte';
+       import '../app.css';
 
-	/** @type {{children: import('svelte').Snippet}} */
-	let { children } = $props();
+       /** @type {{children: import('svelte').Snippet, data: any}} */
+       let { children, data } = $props();
 </script>
 
 <div class="app">
-	<Header />
+       {#if !data?.hideChrome}
+               <Header />
+       {/if}
 
-	<main>
-		{@render children()}
-	</main>
+       <main>
+               {@render children()}
+       </main>
 
-	<footer>
-		<p>
-			visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to learn about SvelteKit
-		</p>
-	</footer>
+       {#if !data?.hideChrome}
+               <footer>
+                       <p>
+                               visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to learn about SvelteKit
+                       </p>
+               </footer>
+       {/if}
 </div>
 
 <style>

--- a/src/routes/music/+layout.js
+++ b/src/routes/music/+layout.js
@@ -1,0 +1,5 @@
+export const prerender = true;
+
+export function load() {
+  return { hideChrome: true };
+}

--- a/src/routes/music/+layout.svelte
+++ b/src/routes/music/+layout.svelte
@@ -3,4 +3,13 @@
   let { children } = $props();
 </script>
 
+<header class="bg-indigo-600 text-white p-4 flex justify-between">
+  <h1 class="font-bold">SoundWave</h1>
+  <a href="#" class="underline">Sign Up</a>
+</header>
+
 {@render children()}
+
+<footer class="bg-indigo-700 text-white text-center p-4 mt-8">
+  <p>&copy; 2025 SoundWave</p>
+</footer>

--- a/src/routes/performance/+layout.js
+++ b/src/routes/performance/+layout.js
@@ -1,0 +1,5 @@
+export const prerender = true;
+
+export function load() {
+  return { hideChrome: true };
+}

--- a/src/routes/performance/+layout.svelte
+++ b/src/routes/performance/+layout.svelte
@@ -3,4 +3,12 @@
   let { children } = $props();
 </script>
 
+<header class="bg-gradient-to-r from-green-500 to-emerald-700 text-white p-4 text-center">
+  <h1 class="text-xl font-bold">Velocity</h1>
+</header>
+
 {@render children()}
+
+<footer class="bg-gray-900 text-gray-400 text-center p-4 mt-8">
+  <p>Powered by Velocity</p>
+</footer>

--- a/src/routes/screensaver/+layout.js
+++ b/src/routes/screensaver/+layout.js
@@ -1,0 +1,5 @@
+export const prerender = true;
+
+export function load() {
+  return { hideChrome: true };
+}

--- a/src/routes/ui/+layout.js
+++ b/src/routes/ui/+layout.js
@@ -1,0 +1,5 @@
+export const prerender = true;
+
+export function load() {
+  return { hideChrome: true };
+}

--- a/src/routes/ui/+layout.svelte
+++ b/src/routes/ui/+layout.svelte
@@ -3,4 +3,12 @@
   let { children } = $props();
 </script>
 
+<header class="bg-gray-800 text-white p-4 text-center">
+  <h1 class="font-bold text-lg">DesignKit</h1>
+</header>
+
 {@render children()}
+
+<footer class="bg-gray-900 text-gray-400 text-center p-4 mt-8">
+  <p>Crafted with SvelteKit</p>
+</footer>


### PR DESCRIPTION
## Summary
- add ability for layout to hide chrome
- create custom headers and footers for marketing examples
- ensure special pages opt out of global chrome

## Testing
- `npm run check` *(fails: svelte-kit not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684240b7aa98832599b233df6eba89ea