### PR TITLE
Ensure nested layouts can hide global chrome

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,13 +1,14 @@
 <script>
-       import Header from './Header.svelte';
-       import '../app.css';
+import Header from './Header.svelte';
+import { page } from '$app/stores';
+import '../app.css';
 
-       /** @type {{children: import('svelte').Snippet, data: any}} */
-       let { children, data } = $props();
+/** @type {{children: import('svelte').Snippet}} */
+let { children } = $props();
 </script>
 
 <div class="app">
-       {#if !data?.hideChrome}
+       {#if !$page.data.hideChrome}
                <Header />
        {/if}
 
@@ -15,7 +16,7 @@
                {@render children()}
        </main>
 
-       {#if !data?.hideChrome}
+       {#if !$page.data.hideChrome}
                <footer>
                        <p>
                                visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to learn about SvelteKit


### PR DESCRIPTION
## Summary
- let nested routes control whether the global header/footer show up

## Testing
- `npm run check`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684242f59f7c8325bda78dfb27b98881