### PR TITLE
Add template preview pages

### DIFF
--- a/src/lib/templates/Blog.svelte
+++ b/src/lib/templates/Blog.svelte
@@ -1,0 +1,28 @@
+<script>
+  import Hero from '../Hero.svelte';
+  export let data = {
+    hero: {
+      title: 'Company Blog',
+      subtitle: 'Thought leadership and news.',
+      image: 'https://images.unsplash.com/photo-1485217988980-11786ced9454?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Read Articles',
+      ctaLink: '#'
+    },
+    posts: [
+      { title: 'Our Latest Project', date: 'May 2' },
+      { title: 'Industry Trends 2024', date: 'April 18' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<section class="py-16 max-w-2xl mx-auto">
+  <ul class="space-y-6">
+    {#each data.posts as p}
+      <li>
+        <h3 class="text-xl font-semibold">{p.title}</h3>
+        <p class="text-gray-500 text-sm">{p.date}</p>
+      </li>
+    {/each}
+  </ul>
+</section>

--- a/src/lib/templates/CaseStudy.svelte
+++ b/src/lib/templates/CaseStudy.svelte
@@ -1,0 +1,20 @@
+<script>
+  import Hero from '../Hero.svelte';
+  export let data = {
+    hero: {
+      title: 'Success Story',
+      subtitle: 'How we delivered amazing results.',
+      image: 'https://images.unsplash.com/photo-1556761175-129418cb2dfe?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Read More',
+      ctaLink: '#'
+    },
+    quote: '"This campaign exceeded all expectations."',
+    attribution: 'Happy Client'
+  };
+</script>
+
+<Hero {...data.hero} />
+<section class="py-16 bg-gray-100 text-center">
+  <blockquote class="text-xl italic mb-4">{data.quote}</blockquote>
+  <p class="font-semibold">{data.attribution}</p>
+</section>

--- a/src/lib/templates/ComponentShowcase.svelte
+++ b/src/lib/templates/ComponentShowcase.svelte
@@ -1,0 +1,21 @@
+<script>
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'Component Library Showcase',
+      subtitle: 'Reusable pieces for rapid development.',
+      image: 'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Browse Components',
+      ctaLink: '#'
+    },
+    features: [
+      { icon: '', title: 'Buttons', text: 'Various styles and sizes.' },
+      { icon: '', title: 'Layouts', text: 'Responsive and flexible.' },
+      { icon: '', title: 'Forms', text: 'Accessible inputs and controls.' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />

--- a/src/lib/templates/CreativeCampaign.svelte
+++ b/src/lib/templates/CreativeCampaign.svelte
@@ -1,0 +1,18 @@
+<script>
+  import Hero from '../Hero.svelte';
+  export let data = {
+    hero: {
+      title: 'Creative Campaign',
+      subtitle: 'Showcase your best work with media-rich content.',
+      image: 'https://images.unsplash.com/photo-1522199710521-72d69614c702?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'View Campaign',
+      ctaLink: '#'
+    },
+    video: 'https://www.w3schools.com/html/mov_bbb.mp4'
+  };
+</script>
+
+<Hero {...data.hero} />
+<section class="py-16 text-center">
+  <video class="mx-auto rounded-lg shadow-lg" src={data.video} controls width="640"></video>
+</section>

--- a/src/lib/templates/EventsWebinars.svelte
+++ b/src/lib/templates/EventsWebinars.svelte
@@ -1,0 +1,28 @@
+<script>
+  import Hero from '../Hero.svelte';
+  export let data = {
+    hero: {
+      title: 'Events & Webinars',
+      subtitle: 'Join us for upcoming sessions.',
+      image: 'https://images.unsplash.com/photo-1531058020387-3be344556be6?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Register Now',
+      ctaLink: '#'
+    },
+    events: [
+      { name: 'Launch Webinar', date: 'June 15' },
+      { name: 'Workshop', date: 'July 12' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<section class="py-16 max-w-2xl mx-auto">
+  <ul class="space-y-4">
+    {#each data.events as e}
+      <li class="flex justify-between border-b pb-2">
+        <span>{e.name}</span>
+        <span class="font-semibold">{e.date}</span>
+      </li>
+    {/each}
+  </ul>
+</section>

--- a/src/lib/templates/HeroFeature.svelte
+++ b/src/lib/templates/HeroFeature.svelte
@@ -1,0 +1,33 @@
+<script>
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'Product Landing',
+      subtitle: 'Catchy tagline here.',
+      image: 'https://images.unsplash.com/photo-1506765515384-028b60a970df?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Learn More',
+      ctaLink: '#'
+    },
+    features: [
+      {
+        icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3h18M6 5v14m12-14v14" /></svg>`,
+        title: 'Fast',
+        text: 'Optimized performance out of the box.'
+      },
+      {
+        icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m6-6H6" /></svg>`,
+        title: 'Scalable',
+        text: 'Grow without limits.'
+      },
+      {
+        icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v18m9-9H3" /></svg>`,
+        title: 'Reliable',
+        text: 'Built with best practices.'
+      }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />

--- a/src/lib/templates/InteractiveDemo.svelte
+++ b/src/lib/templates/InteractiveDemo.svelte
@@ -1,0 +1,29 @@
+<script>
+  import Hero from '../Hero.svelte';
+  import { onMount } from 'svelte';
+  /** @type {HTMLCanvasElement} */
+  let canvas;
+  /** @type {CanvasRenderingContext2D} */
+  let ctx;
+  onMount(() => {
+    canvas.width = 400;
+    canvas.height = 200;
+    ctx = /** @type {CanvasRenderingContext2D} */ (canvas.getContext('2d'));
+    ctx.fillStyle = 'var(--color-theme-1)';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+  });
+  export let data = {
+    hero: {
+      title: 'Interactive Demo',
+      subtitle: 'Engage visitors with live experiences.',
+      image: 'https://images.unsplash.com/photo-1497215842964-222b430dc094?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Try It',
+      ctaLink: '#'
+    }
+  };
+</script>
+
+<Hero {...data.hero} />
+<section class="py-16 text-center">
+  <canvas bind:this={canvas} class="mx-auto rounded shadow"></canvas>
+</section>

--- a/src/lib/templates/Pricing.svelte
+++ b/src/lib/templates/Pricing.svelte
@@ -1,0 +1,29 @@
+<script>
+  import Hero from '../Hero.svelte';
+  export let data = {
+    hero: {
+      title: 'Pricing Plans',
+      subtitle: 'Find a package that fits your needs.',
+      image: 'https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Sign Up',
+      ctaLink: '#'
+    },
+    plans: [
+      { name: 'Basic', price: '$9/mo' },
+      { name: 'Pro', price: '$29/mo' },
+      { name: 'Enterprise', price: 'Contact Us' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<section class="py-16 text-center">
+  <div class="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">
+    {#each data.plans as p}
+      <div class="border rounded-lg p-6 shadow">
+        <h3 class="text-xl font-semibold mb-2">{p.name}</h3>
+        <p class="text-2xl font-bold">{p.price}</p>
+      </div>
+    {/each}
+  </div>
+</section>

--- a/src/lib/templates/ProductOverview.svelte
+++ b/src/lib/templates/ProductOverview.svelte
@@ -1,0 +1,21 @@
+<script>
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'Product Overview',
+      subtitle: 'Technical highlights and specs.',
+      image: 'https://images.unsplash.com/photo-1518773553398-650c184e0bb3?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Get Started',
+      ctaLink: '#'
+    },
+    features: [
+      { icon: '', title: 'Speed', text: 'Benchmarks that impress.' },
+      { icon: '', title: 'Security', text: 'Enterprise-grade protection.' },
+      { icon: '', title: 'Integrations', text: 'Connect to your favorite tools.' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />

--- a/src/lib/templates/ResourceCenter.svelte
+++ b/src/lib/templates/ResourceCenter.svelte
@@ -1,0 +1,26 @@
+<script>
+  import Hero from '../Hero.svelte';
+  export let data = {
+    hero: {
+      title: 'Download Center',
+      subtitle: 'White papers, toolkits and more.',
+      image: 'https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Browse Resources',
+      ctaLink: '#'
+    },
+    resources: [
+      { name: 'Style Guide', link: '#' },
+      { name: 'Brand Toolkit', link: '#' },
+      { name: 'Research Report', link: '#' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<section class="py-16 max-w-4xl mx-auto">
+  <ul class="list-disc pl-5">
+    {#each data.resources as r}
+      <li><a class="text-blue-600 underline" href={r.link}>{r.name}</a></li>
+    {/each}
+  </ul>
+</section>

--- a/src/lib/templates/index.js
+++ b/src/lib/templates/index.js
@@ -1,0 +1,23 @@
+import HeroFeature from './HeroFeature.svelte';
+import CaseStudy from './CaseStudy.svelte';
+import ProductOverview from './ProductOverview.svelte';
+import CreativeCampaign from './CreativeCampaign.svelte';
+import ComponentShowcase from './ComponentShowcase.svelte';
+import InteractiveDemo from './InteractiveDemo.svelte';
+import ResourceCenter from './ResourceCenter.svelte';
+import EventsWebinars from './EventsWebinars.svelte';
+import Pricing from './Pricing.svelte';
+import Blog from './Blog.svelte';
+
+export const templates = [
+  { id: 'hero-feature', name: 'Hero + Feature Grid', component: HeroFeature },
+  { id: 'case-study', name: 'Case Study', component: CaseStudy },
+  { id: 'product-overview', name: 'Product Overview', component: ProductOverview },
+  { id: 'creative-campaign', name: 'Creative Campaign', component: CreativeCampaign },
+  { id: 'component-showcase', name: 'Component Library Showcase', component: ComponentShowcase },
+  { id: 'interactive-demo', name: 'Interactive Demo', component: InteractiveDemo },
+  { id: 'resource-center', name: 'Download/Resource Center', component: ResourceCenter },
+  { id: 'events-webinars', name: 'Events and Webinars', component: EventsWebinars },
+  { id: 'pricing', name: 'Pricing or Services Overview', component: Pricing },
+  { id: 'blog', name: 'Blog/News Section', component: Blog }
+];

--- a/src/routes/templates/+page.svelte
+++ b/src/routes/templates/+page.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { templates } from '$lib/templates';
+  import { base } from '$app/paths';
+</script>
+
+<h1 class="text-2xl font-bold mb-4">Page Templates</h1>
+<ul class="space-y-2">
+  {#each templates as t}
+    <li>
+      <a class="text-blue-600 underline" href={`${base}/templates/${t.id}`}>{t.name}</a>
+    </li>
+  {/each}
+</ul>

--- a/src/routes/templates/[template]/+page.js
+++ b/src/routes/templates/[template]/+page.js
@@ -1,0 +1,5 @@
+export const prerender = true;
+
+export function load({ params }) {
+  return { template: params.template };
+}

--- a/src/routes/templates/[template]/+page.svelte
+++ b/src/routes/templates/[template]/+page.svelte
@@ -1,0 +1,12 @@
+<script>
+  import { templates } from '$lib/templates';
+  export let data;
+  const entry = templates.find((t) => t.id === data.template);
+  const Component = entry ? entry.component : null;
+</script>
+
+{#if Component}
+  <svelte:component this={Component} />
+{:else}
+  <p class="text-red-600">Template not found.</p>
+{/if}


### PR DESCRIPTION
## Summary
- add template components for hero-feature, case-study and more
- register templates in `src/lib/templates/index.js`
- provide `/templates` listing page and dynamic `/templates/[template]` preview route
- canvas demo typed via JSDoc

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68424575c040832592a1fce7ab47d023