### PR TITLE
Add federal marketing landing pages

### DIFF
--- a/src/lib/templates/AssociationsLanding.svelte
+++ b/src/lib/templates/AssociationsLanding.svelte
@@ -1,0 +1,26 @@
+<script>
+  export const displayName = 'Associations Landing';
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'Association Technology Partners',
+      subtitle: 'Streamline member services with flexible open source tools.',
+      image: 'https://images.unsplash.com/photo-1526948128573-703ee1aeb6fa?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Enhance Engagement',
+      ctaLink: '#'
+    },
+    features: [
+      { icon: '', title: 'Custom Portals', text: 'Tailored member experiences across devices.' },
+      { icon: '', title: 'Event Management', text: 'Integrated solutions for conferences and webinars.' },
+      { icon: '', title: 'Data Insights', text: 'Analytics to help grow and retain membership.' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Elevate your association with open source.</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Learn More</a>
+</section>

--- a/src/lib/templates/DolLanding.svelte
+++ b/src/lib/templates/DolLanding.svelte
@@ -1,0 +1,26 @@
+<script>
+  export const displayName = 'DOL Landing';
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'DOL Workforce Solutions',
+      subtitle: 'Robust platforms for labor programs and compliance.',
+      image: 'https://images.unsplash.com/photo-1581511635482-b24b84af2451?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Advance Technology',
+      ctaLink: '#'
+    },
+    features: [
+      { icon: '', title: 'Accessible Web Apps', text: 'Section 508 compliant solutions for all workers.' },
+      { icon: '', title: 'Case Management', text: 'Streamlined workflows for program administration.' },
+      { icon: '', title: 'Secure Cloud Deployment', text: 'FedRAMP-ready infrastructure for sensitive data.' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Empower the workforce with modern tools.</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Talk to Experts</a>
+</section>

--- a/src/lib/templates/FederalOpenSource.svelte
+++ b/src/lib/templates/FederalOpenSource.svelte
@@ -1,0 +1,26 @@
+<script>
+  export const displayName = 'Federal Open Source Solutions';
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'Open Source for Federal Agencies',
+      subtitle: 'Modern, secure solutions tailored for government missions.',
+      image: 'https://images.unsplash.com/photo-1581093588401-22c1d34b014d?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Explore Services',
+      ctaLink: '#'
+    },
+    features: [
+      { icon: '', title: 'Compliance-Ready', text: 'Built to meet federal standards from FISMA to FedRAMP.' },
+      { icon: '', title: 'Open Source Experts', text: 'Leverage community-driven innovation without vendor lock-in.' },
+      { icon: '', title: 'Agile Delivery', text: 'Rapid iterations ensure your mission stays on schedule.' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Ready to modernize your agency?</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Contact Us</a>
+</section>

--- a/src/lib/templates/HhsLanding.svelte
+++ b/src/lib/templates/HhsLanding.svelte
@@ -1,0 +1,26 @@
+<script>
+  export const displayName = 'HHS Landing';
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'HHS Digital Transformation',
+      subtitle: 'Modernize public health platforms with open source technology.',
+      image: 'https://images.unsplash.com/photo-1600880292089-90a7e086ee5a?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Start Your Project',
+      ctaLink: '#'
+    },
+    features: [
+      { icon: '', title: 'Interoperable Systems', text: 'Streamline data exchange across agencies.' },
+      { icon: '', title: 'Compliance Ready', text: 'Security standards for HIPAA and federal mandates.' },
+      { icon: '', title: 'Scalable Architecture', text: 'Cloud-native deployments for nationwide reach.' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">See how open source accelerates health services.</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Contact Us</a>
+</section>

--- a/src/lib/templates/NihLanding.svelte
+++ b/src/lib/templates/NihLanding.svelte
@@ -1,0 +1,26 @@
+<script>
+  export const displayName = 'NIH Landing';
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'NIH Open Source Innovations',
+      subtitle: 'Accelerate medical breakthroughs with secure, agile software.',
+      image: 'https://images.unsplash.com/photo-1581092919545-6ac1c88686a9?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Schedule a Consultation',
+      ctaLink: '#'
+    },
+    features: [
+      { icon: '', title: 'Research-Focused', text: 'Solutions built for biomedical data and collaboration.' },
+      { icon: '', title: 'Security & Compliance', text: 'HIPAA and FISMA-ready architectures.' },
+      { icon: '', title: 'Collaborative Expertise', text: 'Open source communities working with NIH scientists.' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Ready to modernize your research?</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Get Started</a>
+</section>

--- a/src/lib/templates/UsdaLanding.svelte
+++ b/src/lib/templates/UsdaLanding.svelte
@@ -1,0 +1,26 @@
+<script>
+  export const displayName = 'USDA Landing';
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'USDA Open Source Services',
+      subtitle: 'Empowering agriculture with secure, modern software.',
+      image: 'https://images.unsplash.com/photo-1561473808-699bb252c79b?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Transform Operations',
+      ctaLink: '#'
+    },
+    features: [
+      { icon: '', title: 'Data-Driven Agriculture', text: 'Harness analytics to improve crop yields and food safety.' },
+      { icon: '', title: 'Rural Connectivity', text: 'Solutions optimized for field work and remote teams.' },
+      { icon: '', title: 'Sustainable Solutions', text: 'Technology that supports conservation and efficiency.' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Grow your mission with open source.</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Get in Touch</a>
+</section>

--- a/src/routes/associations/+page.svelte
+++ b/src/routes/associations/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Template from '$lib/templates/AssociationsLanding.svelte';
+</script>
+
+<Template />

--- a/src/routes/dol/+page.svelte
+++ b/src/routes/dol/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Template from '$lib/templates/DolLanding.svelte';
+</script>
+
+<Template />

--- a/src/routes/federal/+page.svelte
+++ b/src/routes/federal/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Template from '$lib/templates/FederalOpenSource.svelte';
+</script>
+
+<Template />

--- a/src/routes/hhs/+page.svelte
+++ b/src/routes/hhs/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Template from '$lib/templates/HhsLanding.svelte';
+</script>
+
+<Template />

--- a/src/routes/nih/+page.svelte
+++ b/src/routes/nih/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Template from '$lib/templates/NihLanding.svelte';
+</script>
+
+<Template />

--- a/src/routes/usda/+page.svelte
+++ b/src/routes/usda/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Template from '$lib/templates/UsdaLanding.svelte';
+</script>
+
+<Template />


### PR DESCRIPTION
## Summary
- add landing page templates for Federal Open Source, NIH, HHS, USDA, DOL and Associations
- expose new routes for each template
- run `npm install` and `npm run check`

## Testing
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68424e2ee9b08325aabf618e71f742d8