### PR TITLE
Remove navigation elements from example pages

### DIFF
--- a/src/routes/music/+layout.svelte
+++ b/src/routes/music/+layout.svelte
@@ -3,13 +3,4 @@
   let { children } = $props();
 </script>
 
-<header class="bg-indigo-600 text-white p-4 flex justify-between">
-  <h1 class="font-bold">SoundWave</h1>
-  <a href="#" class="underline">Sign Up</a>
-</header>
-
 {@render children()}
-
-<footer class="bg-indigo-700 text-white text-center p-4 mt-8">
-  <p>&copy; 2025 SoundWave</p>
-</footer>

--- a/src/routes/music/+page.svelte
+++ b/src/routes/music/+page.svelte
@@ -5,18 +5,18 @@
   const features = [
     {
       icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M9 18V5l12-2v13" /></svg>`,
-      title: 'Hi‑Fi Sound',
-      text: 'Crystal clear audio engineered for true music lovers.'
+      title: 'Lossless Streaming',
+      text: 'Enjoy studio-quality tracks without compression.'
     },
     {
       icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-2M9 12l10.5-2M9 15l7.125-1.357" /><path stroke-linecap="round" stroke-linejoin="round" d="M9 9v12.75a.75.75 0 01-1.06.697l-4.5-2.25A.75.75 0 013 19.75V7.913a.75.75 0 01.44-.685L8 5.158a.75.75 0 011 .685V9z" /></svg>`,
       title: 'Offline Playback',
-      text: 'Download your favorites and listen anywhere.'
+      text: 'Save albums to your device for travel and remote listening.'
     },
     {
       icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M9.75 15.75v2.25A2.25 2.25 0 0012 20.25h0a2.25 2.25 0 002.25-2.25v-2.25M12 13.5v6m0 0h3.164c.597 0 1.079-.463 1.079-1.033a10.5 10.5 0 00-8.486 0c0 .57.482 1.033 1.08 1.033H12z" /><circle cx="12" cy="7" r="4.5" /></svg>`,
-      title: 'Curated Playlists',
-      text: 'Fresh tracks handpicked every single day.'
+      title: 'Personalized Radio',
+      text: 'Auto-generated stations that match your taste.'
     }
   ];
 </script>

--- a/src/routes/performance/+layout.svelte
+++ b/src/routes/performance/+layout.svelte
@@ -3,12 +3,4 @@
   let { children } = $props();
 </script>
 
-<header class="bg-gradient-to-r from-green-500 to-emerald-700 text-white p-4 text-center">
-  <h1 class="text-xl font-bold">Velocity</h1>
-</header>
-
 {@render children()}
-
-<footer class="bg-gray-900 text-gray-400 text-center p-4 mt-8">
-  <p>Powered by Velocity</p>
-</footer>

--- a/src/routes/performance/+page.svelte
+++ b/src/routes/performance/+page.svelte
@@ -6,17 +6,17 @@
     {
       icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3h18l-1.5 2.25L21 7.5H3L4.5 5.25 3 3z" /><path stroke-linecap="round" stroke-linejoin="round" d="M3 7.5h18v11.25A1.5 1.5 0 0119.5 20.25h-15A1.5 1.5 0 013 18.75V7.5z" /></svg>`,
       title: 'Blazing Fast',
-      text: 'Optimized for speed from the ground up.'
+      text: 'Built with rigorous benchmarks to ensure top performance.'
     },
     {
       icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3h18M6 5v14m12-14v14" /></svg>`,
-      title: 'Scalable',
-      text: 'Handles projects big and small with ease.'
+      title: 'Horizontally Scalable',
+      text: 'Deploy across clusters without configuration headaches.'
     },
     {
       icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><circle cx="12" cy="12" r="9" /><path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l3 3" /></svg>`,
       title: 'Real-time Updates',
-      text: 'Stay in sync with live data at all times.'
+      text: 'Streams changes instantly to every connected client.'
     }
   ];
 </script>

--- a/src/routes/ui/+layout.svelte
+++ b/src/routes/ui/+layout.svelte
@@ -3,12 +3,4 @@
   let { children } = $props();
 </script>
 
-<header class="bg-gray-800 text-white p-4 text-center">
-  <h1 class="font-bold text-lg">DesignKit</h1>
-</header>
-
 {@render children()}
-
-<footer class="bg-gray-900 text-gray-400 text-center p-4 mt-8">
-  <p>Crafted with SvelteKit</p>
-</footer>

--- a/src/routes/ui/+page.svelte
+++ b/src/routes/ui/+page.svelte
@@ -6,17 +6,17 @@
     {
       icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3h18M9 3v18m6-18v18M3 21h18" /></svg>`,
       title: 'Responsive Layouts',
-      text: 'Looks stunning on phones, tablets and desktops.'
+      text: 'Adaptable components that look great on any screen.'
     },
     {
       icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5L21 12l-7.5 7.5M10.5 19.5L3 12l7.5-7.5" /></svg>`,
       title: 'Intuitive Controls',
-      text: 'Simple, familiar interface designed for productivity.'
+      text: 'Familiar interactions modeled after industry standards.'
     },
     {
       icon: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-12 h-12 mx-auto"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6h15m-15 6h15m-15 6h15" /></svg>`,
       title: 'Accessible',
-      text: 'Built with best practices for every user in mind.'
+      text: 'Keyboard friendly and screen reader tested.'
     }
   ];
 </script>


### PR DESCRIPTION
## Summary
- strip header/footer from demo layouts
- flesh out example page feature lists with unique details

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842510476fc8325afd06a71ee8b52ac