### PR TITLE
Add Svelte and AI landing templates

### DIFF
--- a/src/lib/templates/AiLanding.svelte
+++ b/src/lib/templates/AiLanding.svelte
@@ -1,0 +1,26 @@
+<script>
+  export const displayName = 'AI Capabilities';
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'Artificial Intelligence Solutions',
+      subtitle: 'Automate, analyze, and engage at scale.',
+      image: 'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'See the Power',
+      ctaLink: '#'
+    },
+    features: [
+      { icon: '', title: 'Automation', text: 'Streamline workflows with intelligent decision making.' },
+      { icon: '', title: 'Insights', text: 'Leverage data-driven predictions to drive marketing.' },
+      { icon: '', title: 'Personalization', text: 'Deliver content that adapts to each user in real time.' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Elevate campaigns with AI</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Learn More</a>
+</section>

--- a/src/lib/templates/SvelteAiLanding.svelte
+++ b/src/lib/templates/SvelteAiLanding.svelte
@@ -1,0 +1,38 @@
+<script>
+  export const displayName = 'Svelte + AI Landing';
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'Svelte & AI',
+      subtitle: 'Build reactive apps supercharged with artificial intelligence.',
+      image: 'https://images.unsplash.com/photo-1538899411-528f4176c095?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Discover More',
+      ctaLink: '#'
+    },
+    features: [
+      {
+        icon: '',
+        title: 'Reactive Framework',
+        text: 'Svelte offers a lightning-fast developer experience with minimal overhead.'
+      },
+      {
+        icon: '',
+        title: 'AI Integrations',
+        text: 'Connect intelligent models to automate workflows and personalize content.'
+      },
+      {
+        icon: '',
+        title: 'Marketing Agility',
+        text: 'Deploy campaigns quickly using flexible, component-based templates.'
+      }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Explore templates built with SvelteKit</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Get Started</a>
+</section>

--- a/src/lib/templates/SvelteLanding.svelte
+++ b/src/lib/templates/SvelteLanding.svelte
@@ -1,0 +1,26 @@
+<script>
+  export const displayName = 'Svelte Capabilities';
+  import Hero from '../Hero.svelte';
+  import Features from '../Features.svelte';
+  export let data = {
+    hero: {
+      title: 'Svelte for Modern Web Apps',
+      subtitle: 'Ship faster with a truly reactive framework.',
+      image: 'https://images.unsplash.com/photo-1504805572947-34fad45aed93?auto=format&fit=crop&w=1200&q=80',
+      ctaText: 'Learn Svelte',
+      ctaLink: '#'
+    },
+    features: [
+      { icon: '', title: 'No Virtual DOM', text: 'Compile-time optimizations for unbeatable performance.' },
+      { icon: '', title: 'Concise Components', text: 'Write less code and achieve more with built-in reactivity.' },
+      { icon: '', title: 'Great Developer Experience', text: 'Enjoy first-class tooling with hot module reloading.' }
+    ]
+  };
+</script>
+
+<Hero {...data.hero} />
+<Features features={data.features} />
+<section class="bg-gray-900 text-white py-16 text-center">
+  <h2 class="text-3xl font-bold mb-4">Ready to build with Svelte?</h2>
+  <a href="#" class="inline-block bg-white text-gray-900 font-semibold px-6 py-3 rounded-md shadow">Start Coding</a>
+</section>

--- a/src/routes/ai/+page.svelte
+++ b/src/routes/ai/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Template from '$lib/templates/AiLanding.svelte';
+</script>
+
+<Template />

--- a/src/routes/svelte-ai/+page.svelte
+++ b/src/routes/svelte-ai/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Template from '$lib/templates/SvelteAiLanding.svelte';
+</script>
+
+<Template />

--- a/src/routes/svelte/+page.svelte
+++ b/src/routes/svelte/+page.svelte
@@ -1,0 +1,5 @@
+<script>
+  import Template from '$lib/templates/SvelteLanding.svelte';
+</script>
+
+<Template />


### PR DESCRIPTION
## Summary
- create marketing templates for Svelte, AI and combined Svelte + AI use
- add routes `/svelte`, `/ai` and `/svelte-ai`

## Testing
- `npm install`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6842536503a08325bdcfd1eb760d74bc