### PR TITLE
Refine project reset script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
 
+## About WebFirst
+
+This example project is maintained by **WebFirst, Inc.**, a leader in federal contracting for software development and strategy. WebFirst delivers dependable, high-quality web solutions for agencies across the U.S. government, and this starter kit reflects that commitment to excellence.
+
 ## Creating a project
 
 If you're seeing this, you've probably already done this step. Congrats!
@@ -53,6 +57,10 @@ node scripts/create-page.js pricing pricing
 ```
 
 The script creates `src/routes/<slug>/+page.svelte` that renders the selected template component.
+
+## Resetting the Project
+
+Run `npm run reset` to reinstall dependencies, remove build artifacts (including `node_modules`, `.svelte-kit` and the generated `docs` directory) and rebuild the application from a clean slate. This command invokes `scripts/reset-project.js` under the hood and also runs `npm run check` to verify the project.
 
 ## Deployment
 

--- a/package.json
+++ b/package.json
@@ -1,31 +1,32 @@
 {
-	"name": "octo-presso",
-	"private": true,
-	"version": "0.0.1",
-	"type": "module",
-	"scripts": {
-		"dev": "vite dev",
-		"build": "vite build",
-		"preview": "vite preview",
-		"prepare": "svelte-kit sync || echo ''",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch"
-	},
-	"devDependencies": {
-		"@fontsource/fira-mono": "^5.0.0",
-		"@neoconfetti/svelte": "^2.0.0",
-		"@sveltejs/adapter-auto": "^6.0.0",
-		"@sveltejs/adapter-static": "^3.0.8",
-		"@sveltejs/kit": "^2.16.0",
-		"@sveltejs/vite-plugin-svelte": "^5.0.0",
-		"@tailwindcss/typography": "^0.5.10",
-		"autoprefixer": "^10.4.0",
-		"marked": "^12.0.0",
-		"postcss": "^8.4.38",
-		"svelte": "^5.25.0",
-		"svelte-check": "^4.0.0",
-		"tailwindcss": "^3.4.1",
-		"typescript": "^5.0.0",
-		"vite": "^6.2.6"
-	}
+  "name": "octo-presso",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview",
+    "prepare": "svelte-kit sync || echo ''",
+    "check": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json",
+    "check:watch": "svelte-kit sync && svelte-check --tsconfig ./jsconfig.json --watch",
+    "reset": "node scripts/reset-project.js"
+  },
+  "devDependencies": {
+    "@fontsource/fira-mono": "^5.0.0",
+    "@neoconfetti/svelte": "^2.0.0",
+    "@sveltejs/adapter-auto": "^6.0.0",
+    "@sveltejs/adapter-static": "^3.0.8",
+    "@sveltejs/kit": "^2.16.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "@tailwindcss/typography": "^0.5.10",
+    "autoprefixer": "^10.4.0",
+    "marked": "^12.0.0",
+    "postcss": "^8.4.38",
+    "svelte": "^5.25.0",
+    "svelte-check": "^4.0.0",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.0.0",
+    "vite": "^6.2.6"
+  }
 }

--- a/scripts/reset-project.js
+++ b/scripts/reset-project.js
@@ -1,0 +1,30 @@
+import { rm } from 'fs/promises';
+import { execSync } from 'child_process';
+
+const CLEAN_DIRS = ['node_modules', '.svelte-kit', 'docs'];
+
+async function reset() {
+  console.log('Cleaning build artifacts...');
+  for (const dir of CLEAN_DIRS) {
+    await rm(dir, { recursive: true, force: true });
+  }
+
+  console.log('Installing dependencies...');
+  execSync('npm ci', { stdio: 'inherit' });
+
+  console.log('Building site...');
+  execSync('npm run build', {
+    stdio: 'inherit',
+    env: { ...process.env, NODE_ENV: 'production' }
+  });
+
+  console.log('Running checks...');
+  execSync('npm run check', { stdio: 'inherit' });
+
+  console.log('Project reset complete!');
+}
+
+reset().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- expand WebFirst background in README
- document new `npm run reset` usage and cleanup behavior
- improve `scripts/reset-project.js` to clean `.svelte-kit` and run checks

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_684254a2583c8325967ac18501666602